### PR TITLE
Add ConditionSettings definition to ViewModel

### DIFF
--- a/packages/sitecore-jss-forms/src/ViewModel.ts
+++ b/packages/sitecore-jss-forms/src/ViewModel.ts
@@ -6,12 +6,36 @@ export interface ValidationDataModel {
   name: string;
 }
 
+export interface ConditionsModel { 
+    fieldId: string;
+    operatorId: string;
+    value: string;
+}
+
+export interface ActionsModel {
+    fieldId: string;
+    actionTypeId: string;
+    value: string;
+}
+
+export interface FieldConditionsModel { 
+    matchTypeId: string;
+    conditions: ConditionsModel[];
+    actions: ActionsModel[];
+}
+
+export interface ConditionSettingsModel {
+    fieldKey: string;
+    fieldConditions: FieldConditionsModel[];
+}
+
 export interface ViewModel {
   itemId: string;
   name: string;
   templateId: string;
   fieldTypeItemId: string;
   validationDataModels: ValidationDataModel[];
+  conditionSettings: ConditionSettingsModel;
 }
 
 export interface TextViewModel extends ViewModel {


### PR DESCRIPTION
Add in the missing conditionSettings field to the jss-forms ViewModel.

## Description
The JSS forms package is the condition settings data model, this force using any or extending typings when implementing any conditions based field code.  
This PR adds the additional data that Sitecore returns in the JSON payload.

## Motivation
Allows users of this package to create type-safe implementations of field conditions.

## How Has This Been Tested?
This PR adds typings only so shouldn't affect user code adversely unless someone has added typings into their code.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update (non-breaking change; modified files are limited to the `/docs` directory)

## Checklist:
- [x] I have read the Contributing guide.
- [x] My code follows the code style of this project.
- [ ] My code/comments/docs fully adhere to the Code of Conduct.
- [ ] My change is a code change and it requires an update to the documentation.
- [ ] My change is a documentation change and it requires an update to the navigation.
